### PR TITLE
Make context property of Matcher protected and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ async function example() {
     .with('bagna cauda', async () => await asyncFunction2())
     .otherwise(async () => await asyncCereaFunction());
 
-  console.log(result); // Output: 'bagna cauda'
+  console.log(result); // Output: asyncFunction2 output...
 }
 ```
 ### Matching Class Instances (Synchronous)
@@ -32,8 +32,8 @@ try {
   throw new BoiaFausError();
 } catch (ex) {
   const res = match(ex)
-    .with(TurnaSiError, () => 'Handled TurnaSiError')
-    .with(BoiaFausError, () => 'Handled BoiaFausError')
+    .withType(TurnaSiError, () => 'Handled TurnaSiError')
+    .withType(BoiaFausError, () => 'Handled BoiaFausError')
     .otherwise(() => 'Cerea!')
     .return();
 
@@ -62,7 +62,7 @@ console.log(res);
 // ]
 ```
 ## API
-### `match(value)`
+### `.match(value)`
 Initializes a matcher for the given value. The value can be a primitive, an object, or an exception.
 ### `.with(condition, handler)`
 Defines a condition and its corresponding handler:
@@ -83,17 +83,17 @@ Extracts a value from the matched input:
 ### `.matching(matcher)`
 Changes the matcher to be applied from that point forward:
 - matcher: A function that determines how subsequent matching will be applied.
-### `first()`
+### `.first()`
 Executes only the first handler that matches the condition. Useful for cases where you only need to handle the first match. This is the default behavior
-### `any()`
+### `.any()`
 Executes all handlers that match the condition. Useful for cases where you want to handle multiple matches.
 ### `.not()`
 Negates the condition, meaning the next statement will match only if the condition is false.
 ### `.yet()`
 Affirms the condition, meaning the next statement will match only if the condition is true.
-### `one()`
+### `.one()`
 Returns only the first matched value. This is the default behavior.
-### `all()`
+### `.all()`
 Returns an array of results, allowing you to capture all matched values.
 ### `.otherwise(handler)`
 Defines a fallback handler to execute if no conditions match:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciaplu",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A TypeScript library implementing Pattern Matching for declarative matching of values or types, with support for both synchronous and asynchronous handlers.",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
 import { Matcher } from "./matcher/matcher";
 
 export const match = (value: any) => new Matcher(value)
+export { Matcher };

--- a/src/matcher/matcher.ts
+++ b/src/matcher/matcher.ts
@@ -50,7 +50,7 @@ export class Matcher<T> extends Promise<any> {
 
   with(
     value: any,
-    handler: () => Promise<any> | any
+    handler: () => Promise<any> | any = () => true
   ): Matcher<T> {
     this._statements.push(new WithStatement(value, handler));
 
@@ -59,7 +59,7 @@ export class Matcher<T> extends Promise<any> {
 
   withType<U>(
     value: new (...args: any[]) => U,
-    handler: () => Promise<any> | any
+    handler: () => Promise<any> | any = () => true
   ): Matcher<T> {
     this._statements.push(new WithTypeStatement(value, handler));
 
@@ -68,7 +68,7 @@ export class Matcher<T> extends Promise<any> {
 
   when(
     condition: (value: T) => Promise<boolean> | boolean,
-    handler: () => Promise<any> | any
+    handler: () => Promise<any> | any = () => true
   ): Matcher<T> {
     this._statements.push(new WhenStatement(condition, handler));
 

--- a/src/matcher/matcher.ts
+++ b/src/matcher/matcher.ts
@@ -12,7 +12,7 @@ import { ToBeStatement } from "./statements/tobestatement";
 
 export class Matcher<T> extends Promise<any> {
   private _statements: Statement[] = [];
-  private _context: Context;
+  protected _context: Context;
   
   constructor(value: T) {
     super(() => {});
@@ -120,7 +120,7 @@ export class Matcher<T> extends Promise<any> {
   performing(
     matcher: (value1: any, value2: any) => Promise<boolean> | boolean
   ): Matcher<T> {
-    return this.performing(matcher);
+    return this.matching(matcher);
   }
 
   otherwise(handler: () => Promise<any> | any): Matcher<T> {

--- a/test/tests/matcher.test.ts
+++ b/test/tests/matcher.test.ts
@@ -1,5 +1,6 @@
 import t from 'tap';
-import { match } from '../../src/main';
+import { match, Matcher } from '../../src/main';
+import { Context } from '../../src/matcher/statements/context';
 
 t.test('Match string value', async t => {
   const res = await match('string')
@@ -260,6 +261,49 @@ t.test('matchFirst after matchAll', async t => {
   t.same(res, ['cerea', 'buta', 'cerea']);
 });
 
+t.test('matchFirst after matchAll two times with reset context', async t => {
+  class CustomMatcher extends Matcher<any> {
+    private _words: string[] = [];
+
+    addWord(word: string) {
+      this._words.push(word);
+
+      return this._words;
+    };
+
+    reset(value: any) {
+      this._context = new Context(value);
+
+      this._words = [];
+    }
+  }
+
+  const matcher: CustomMatcher = new CustomMatcher('test string with multiple conditions');
+
+  matcher
+    .extracting((value: string) => Promise.resolve(value.split(' ')))
+    .test(async (words, wordCount) => Promise.resolve(words.length === wordCount))
+    .any()
+    .with(5, async () => await matcher.addWord('cerea'))
+    .with(3, async () => Promise.resolve('tinca'))
+    .with(5, async () => await matcher.addWord('buta'))
+    .with(5, async () => await matcher.addWord('cerea'))
+    .first()
+    .with(3, async () => Promise.resolve('tinca'))
+    .with(5, async () => await matcher.addWord('buta'))
+    .otherwise(async () => Promise.resolve('no match found!'))
+
+  const res = await matcher;
+
+  t.same(res, ['cerea', 'buta', 'cerea']);
+
+  matcher.reset('test string with multiple conditions');
+
+  const res2 = await matcher;
+
+  t.same(res2, ['cerea', 'buta', 'cerea']);
+});
+
 t.test('match and extracting', async t => {
   const hex = '00000100';
 
@@ -287,51 +331,3 @@ t.test('match and extracting', async t => {
 
   t.same(res, { ext: 'ico', mime: 'image/x-icon' });
 });
-
-// t.test('match and extracting', async t => {
-//   const call = {
-//     method: 'GET',
-//     url: '/users/1',
-//     headers: {
-//       'Content-Type': 'application/json',
-//       'Accept': 'application/json'
-//     },
-//     body: null,
-//     query: null,
-//     params: {
-//       id: '1'
-//     },
-//     cookies: null,
-//   };
-
-//   const res = match(httpCall)
-//     .extracting((req) => ...) // TODO: estrae tutti i dati della richiesta (metodo, url, headers, body, query, params, cookies, ecc)
-//     .test((httpCall, url) => httpCall.url === url) // TODO: controlla l'url... in realtà dovrebbe usare le regex perché l'url contiene parametri, query, ecc.
-//     .with('/users/:id', () => match()
-//       .test((httpCall, method) => httpCall.method === method) // TODO: controlla il metodo
-//       .with('GET', () => match()
-//         .extracting(...) // qui ci sono i middleware, definiti con più extracting (recupero della sessione, del token, ecc)
-//         .when(...) // qui ci sono i middleware, definiti con più when (per esempio controllo dei permessi, controllo del token, ecc.)
-//         // se uno di questi fallisce, ritorna un eccezione
-//       )
-//       .with('POST', () => ...)
-//       .with('PUT', () => ...)
-//       .with('DELETE', () => ...)
-//     )
-//     .with('/users/', () => match()
-//       .test((httpCall, method) => httpCall.method === method) // TODO: controlla il metodo
-//       .with('GET', () => match()
-//         .extracting(...) // qui ci sono i middleware, definiti con più extracting (recupero della sessione, del token, ecc)
-//         .when(...) // qui ci sono i middleware, definiti con più when (per esempio controllo dei permessi, controllo del token, ecc.)
-//         // se uno di questi fallisce, ritorna un eccezione
-//       )
-//       .with('POST', () => ...)
-//       .with('PUT', () => ...)
-//       .with('DELETE', () => ...)
-//       .otherwise(async () => false)
-//     )
-
-//     // alla fine, viene inviata la risposta
-
-//   t.same(res, { id: '1', name: 'User 1' });
-// });

--- a/test/tests/matcher.test.ts
+++ b/test/tests/matcher.test.ts
@@ -287,3 +287,51 @@ t.test('match and extracting', async t => {
 
   t.same(res, { ext: 'ico', mime: 'image/x-icon' });
 });
+
+// t.test('match and extracting', async t => {
+//   const call = {
+//     method: 'GET',
+//     url: '/users/1',
+//     headers: {
+//       'Content-Type': 'application/json',
+//       'Accept': 'application/json'
+//     },
+//     body: null,
+//     query: null,
+//     params: {
+//       id: '1'
+//     },
+//     cookies: null,
+//   };
+
+//   const res = match(httpCall)
+//     .extracting((req) => ...) // TODO: estrae tutti i dati della richiesta (metodo, url, headers, body, query, params, cookies, ecc)
+//     .test((httpCall, url) => httpCall.url === url) // TODO: controlla l'url... in realtà dovrebbe usare le regex perché l'url contiene parametri, query, ecc.
+//     .with('/users/:id', () => match()
+//       .test((httpCall, method) => httpCall.method === method) // TODO: controlla il metodo
+//       .with('GET', () => match()
+//         .extracting(...) // qui ci sono i middleware, definiti con più extracting (recupero della sessione, del token, ecc)
+//         .when(...) // qui ci sono i middleware, definiti con più when (per esempio controllo dei permessi, controllo del token, ecc.)
+//         // se uno di questi fallisce, ritorna un eccezione
+//       )
+//       .with('POST', () => ...)
+//       .with('PUT', () => ...)
+//       .with('DELETE', () => ...)
+//     )
+//     .with('/users/', () => match()
+//       .test((httpCall, method) => httpCall.method === method) // TODO: controlla il metodo
+//       .with('GET', () => match()
+//         .extracting(...) // qui ci sono i middleware, definiti con più extracting (recupero della sessione, del token, ecc)
+//         .when(...) // qui ci sono i middleware, definiti con più when (per esempio controllo dei permessi, controllo del token, ecc.)
+//         // se uno di questi fallisce, ritorna un eccezione
+//       )
+//       .with('POST', () => ...)
+//       .with('PUT', () => ...)
+//       .with('DELETE', () => ...)
+//       .otherwise(async () => false)
+//     )
+
+//     // alla fine, viene inviata la risposta
+
+//   t.same(res, { id: '1', name: 'User 1' });
+// });


### PR DESCRIPTION
The context property of the Matcher class has been marked as protected to improve encapsulation and prevent direct external modification. Additionally, the related documentation in the markdown file has been updated to reflect this change accurately.